### PR TITLE
fix: use wrapped errors

### DIFF
--- a/cmd/wavtagger/main.go
+++ b/cmd/wavtagger/main.go
@@ -59,12 +59,12 @@ func main() {
 func tagFile(path string) error {
 	in, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("failed to open %s - %v", path, err)
+		return fmt.Errorf("failed to open %s - %w", path, err)
 	}
 	d := wav.NewDecoder(in)
 	buf, err := d.FullPCMBuffer()
 	if err != nil {
-		return fmt.Errorf("couldn't read buffer %s %v", path, err)
+		return fmt.Errorf("couldn't read buffer %s %w", path, err)
 	}
 	in.Close()
 
@@ -74,7 +74,7 @@ func tagFile(path string) error {
 
 	out, err := os.Create(outPath)
 	if err != nil {
-		return fmt.Errorf("couldn't create %s %v", outPath, err)
+		return fmt.Errorf("couldn't create %s %w", outPath, err)
 	}
 	defer out.Close()
 
@@ -84,7 +84,7 @@ func tagFile(path string) error {
 		buf.Format.NumChannels,
 		int(d.WavAudioFormat))
 	if err := e.Write(buf); err != nil {
-		return fmt.Errorf("failed to write audio buffer - %v", err)
+		return fmt.Errorf("failed to write audio buffer - %w", err)
 	}
 	e.Metadata = &wav.Metadata{}
 	if *flagArtist != "" {
@@ -115,7 +115,7 @@ func tagFile(path string) error {
 		e.Metadata.Genre = *flagGenre
 	}
 	if err := e.Close(); err != nil {
-		return fmt.Errorf("failed to close %s - %v", outPath, err)
+		return fmt.Errorf("failed to close %s - %w", outPath, err)
 	}
 	fmt.Println("Tagged file available at", outPath)
 

--- a/cue_chunk.go
+++ b/cue_chunk.go
@@ -62,12 +62,12 @@ func DecodeCueChunk(d *Decoder, ch *riff.Chunk) error {
 		buf := make([]byte, ch.Size)
 		var err error
 		if _, err = ch.Read(buf); err != nil {
-			return fmt.Errorf("failed to read the CUE chunk - %v", err)
+			return fmt.Errorf("failed to read the CUE chunk - %w", err)
 		}
 		r := bytes.NewReader(buf)
 		var nbrCues uint32
 		if err := binary.Read(r, binary.LittleEndian, &nbrCues); err != nil {
-			return fmt.Errorf("failed to read the number of cues - %v", err)
+			return fmt.Errorf("failed to read the number of cues - %w", err)
 		}
 		if nbrCues > 0 {
 			if d.Metadata == nil {

--- a/decoder.go
+++ b/decoder.go
@@ -255,7 +255,7 @@ func (d *Decoder) FullPCMBuffer() (*audio.IntBuffer, error) {
 	sampleBufData := make([]byte, bytesPerSample)
 	decodeF, err := sampleDecodeFunc(int(d.BitDepth))
 	if err != nil {
-		return nil, fmt.Errorf("could not get sample decode func %v", err)
+		return nil, fmt.Errorf("could not get sample decode func %w", err)
 	}
 
 	i := 0
@@ -303,7 +303,7 @@ func (d *Decoder) PCMBuffer(buf *audio.IntBuffer) (n int, err error) {
 	buf.SourceBitDepth = int(d.BitDepth)
 	decodeF, err := sampleDecodeFunc(int(d.BitDepth))
 	if err != nil {
-		return 0, fmt.Errorf("could not get sample decode func %v", err)
+		return 0, fmt.Errorf("could not get sample decode func %w", err)
 	}
 
 	bPerSample := bytesPerSample(int(d.BitDepth))

--- a/encoder.go
+++ b/encoder.go
@@ -150,16 +150,16 @@ func (e *Encoder) writeHeader() error {
 	}
 	// num channels
 	if err := e.AddLE(uint16(e.NumChans)); err != nil {
-		return fmt.Errorf("error encoding the number of channels - %v", err)
+		return fmt.Errorf("error encoding the number of channels - %w", err)
 	}
 	// samplerate
 	if err := e.AddLE(uint32(e.SampleRate)); err != nil {
-		return fmt.Errorf("error encoding the sample rate - %v", err)
+		return fmt.Errorf("error encoding the sample rate - %w", err)
 	}
 	blockAlign := e.NumChans * e.BitDepth / 8
 	// avg bytes per sec
 	if err := e.AddLE(uint32(e.SampleRate * blockAlign)); err != nil {
-		return fmt.Errorf("error encoding the avg bytes per sec - %v", err)
+		return fmt.Errorf("error encoding the avg bytes per sec - %w", err)
 	}
 	// block align
 	if err := e.AddLE(uint16(blockAlign)); err != nil {
@@ -167,7 +167,7 @@ func (e *Encoder) writeHeader() error {
 	}
 	// bits per sample
 	if err := e.AddLE(uint16(e.BitDepth)); err != nil {
-		return fmt.Errorf("error encoding bits per sample - %v", err)
+		return fmt.Errorf("error encoding bits per sample - %w", err)
 	}
 
 	return nil
@@ -185,14 +185,14 @@ func (e *Encoder) Write(buf *audio.IntBuffer) error {
 	if !e.pcmChunkStarted {
 		// sound header
 		if err := e.AddLE(riff.DataFormatID); err != nil {
-			return fmt.Errorf("error encoding sound header %v", err)
+			return fmt.Errorf("error encoding sound header %w", err)
 		}
 		e.pcmChunkStarted = true
 
 		// write a temporary chunksize
 		e.pcmChunkSizePos = e.WrittenBytes
 		if err := e.AddLE(uint32(42)); err != nil {
-			return fmt.Errorf("%v when writing wav data chunk size header", err)
+			return fmt.Errorf("%w when writing wav data chunk size header", err)
 		}
 	}
 
@@ -207,14 +207,14 @@ func (e *Encoder) WriteFrame(value interface{}) error {
 	if !e.pcmChunkStarted {
 		// sound header
 		if err := e.AddLE(riff.DataFormatID); err != nil {
-			return fmt.Errorf("error encoding sound header %v", err)
+			return fmt.Errorf("error encoding sound header %w", err)
 		}
 		e.pcmChunkStarted = true
 
 		// write a temporary chunksize
 		e.pcmChunkSizePos = e.WrittenBytes
 		if err := e.AddLE(uint32(42)); err != nil {
-			return fmt.Errorf("%v when writing wav data chunk size header", err)
+			return fmt.Errorf("%w when writing wav data chunk size header", err)
 		}
 	}
 
@@ -225,10 +225,10 @@ func (e *Encoder) WriteFrame(value interface{}) error {
 func (e *Encoder) writeMetadata() error {
 	chunkData := encodeInfoChunk(e)
 	if err := e.AddBE(CIDList); err != nil {
-		return fmt.Errorf("failed to write the LIST chunk ID: %s", err)
+		return fmt.Errorf("failed to write the LIST chunk ID: %w", err)
 	}
 	if err := e.AddLE(uint32(len(chunkData))); err != nil {
-		return fmt.Errorf("failed to write the LIST chunk size: %s", err)
+		return fmt.Errorf("failed to write the LIST chunk size: %w", err)
 	}
 	return e.AddBE(chunkData)
 }
@@ -244,7 +244,7 @@ func (e *Encoder) Close() error {
 	// metadata chunks
 	if e.Metadata != nil {
 		if err := e.writeMetadata(); err != nil {
-			return fmt.Errorf("failed to write metadata - %v", err)
+			return fmt.Errorf("failed to write metadata - %w", err)
 		}
 	}
 
@@ -253,7 +253,7 @@ func (e *Encoder) Close() error {
 		return err
 	}
 	if err := e.AddLE(uint32(e.WrittenBytes) - 8); err != nil {
-		return fmt.Errorf("%v when writing the total written bytes", err)
+		return fmt.Errorf("%w when writing the total written bytes", err)
 	}
 
 	// rewrite the audio chunk length header
@@ -263,7 +263,7 @@ func (e *Encoder) Close() error {
 		}
 		chunksize := uint32((int(e.BitDepth) / 8) * int(e.NumChans) * e.frames)
 		if err := e.AddLE(uint32(chunksize)); err != nil {
-			return fmt.Errorf("%v when writing wav data chunk size header", err)
+			return fmt.Errorf("%w when writing wav data chunk size header", err)
 		}
 	}
 

--- a/list_chunk.go
+++ b/list_chunk.go
@@ -43,13 +43,13 @@ func DecodeListChunk(d *Decoder, ch *riff.Chunk) error {
 		buf := make([]byte, ch.Size)
 		var err error
 		if _, err = ch.Read(buf); err != nil {
-			return fmt.Errorf("failed to read the LIST chunk - %v", err)
+			return fmt.Errorf("failed to read the LIST chunk - %w", err)
 		}
 		r := bytes.NewReader(buf)
 		// INFO subchunk
 		scratch := make([]byte, 4)
 		if _, err = r.Read(scratch); err != nil {
-			return fmt.Errorf("failed to read the INFO subchunk - %v", err)
+			return fmt.Errorf("failed to read the INFO subchunk - %w", err)
 		}
 		if !bytes.Equal(scratch, CIDInfo[:]) {
 			// "expected an INFO subchunk but got %s", string(scratch)

--- a/smpl_chunk.go
+++ b/smpl_chunk.go
@@ -24,7 +24,7 @@ func DecodeSamplerChunk(d *Decoder, ch *riff.Chunk) error {
 		buf := make([]byte, ch.Size)
 		var err error
 		if _, err = ch.Read(buf); err != nil {
-			return fmt.Errorf("failed to read the smpl chunk - %v", err)
+			return fmt.Errorf("failed to read the smpl chunk - %w", err)
 		}
 		if d.Metadata == nil {
 			d.Metadata = &Metadata{}


### PR DESCRIPTION
Always use wrapped errors so that consumers can test for io.EOF as needed.