### PR TITLE
Change temporary sizes to fix broken pipes

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -129,7 +129,7 @@ func (e *Encoder) writeHeader() error {
 		return err
 	}
 	// file size uint32, to update later on.
-	if err := e.AddLE(uint32(42)); err != nil {
+	if err := e.AddLE(uint32(4294967295)); err != nil {
 		return err
 	}
 	// wave headers
@@ -191,7 +191,7 @@ func (e *Encoder) Write(buf *audio.IntBuffer) error {
 
 		// write a temporary chunksize
 		e.pcmChunkSizePos = e.WrittenBytes
-		if err := e.AddLE(uint32(42)); err != nil {
+		if err := e.AddLE(uint32(4294967295)); err != nil {
 			return fmt.Errorf("%w when writing wav data chunk size header", err)
 		}
 	}
@@ -213,7 +213,7 @@ func (e *Encoder) WriteFrame(value interface{}) error {
 
 		// write a temporary chunksize
 		e.pcmChunkSizePos = e.WrittenBytes
-		if err := e.AddLE(uint32(42)); err != nil {
+		if err := e.AddLE(uint32(4294967295)); err != nil {
 			return fmt.Errorf("%w when writing wav data chunk size header", err)
 		}
 	}


### PR DESCRIPTION
Some software, like VLC, is smart enough to know that if it's being fed from standard input, header information detailing file size and number of bytes written, etc., will probably be irrelevant and totally skips them. However, other software, like FFmpeg, use temporary sizes of 0xFFFFFFFF for pipes. Since FFmpeg/libavformat libraries are so pervasive, using 0xFFFFFFFF will make this package compatible with piping into software using those libraries, while also not breaking software it's already compatible with now.